### PR TITLE
CVSB-17157 - retry up to X times on error

### DIFF
--- a/src/functions/retroGenInit.ts
+++ b/src/functions/retroGenInit.ts
@@ -12,7 +12,7 @@ import {StreamService} from "../services/StreamService";
  * @param context - λ Context
  * @param callback - callback function
  */
-const retroGenInit: Handler = async (event: any, context?: Context, callback?: Callback): Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
+const retroGenInit: Handler = async (event: any, context?: Context, callback?: Callback): Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
     if (!event) {
         console.error("ERROR: event is not defined.");
         return;
@@ -31,10 +31,13 @@ const retroGenInit: Handler = async (event: any, context?: Context, callback?: C
     });
 
     return Promise.all(sendMessagePromises)
-    .catch((error: AWSError) => {
-        console.error(error);
-        throw error;
-    });
+        .catch((error: AWSError) => {
+            console.error(error);
+            console.log("records");
+            console.log(records);
+            // Lambda will retry up to X times or until the message expires, after which the message will be sent to the dlq.
+            throw error;
+        });
 };
 
 export {retroGenInit};

--- a/tests/unit/retroGenInitFunction.unitTest.ts
+++ b/tests/unit/retroGenInitFunction.unitTest.ts
@@ -9,6 +9,15 @@ describe("retroGenInit  Function",  () => {
     jest.restoreAllMocks();
     jest.resetModuleRegistry();
   });
+
+  describe("if the event is undefined", () => {
+    it("should return undefined", async () => {
+      expect.assertions(1);
+      const result = await retroGenInit(undefined, ctx, () => { return; });
+      expect(result).toBe(undefined);
+    });
+  });
+
   describe("with good event", () => {
     it("should invoke SQS service with correct params", async () => {
       const sendMessage = jest.fn().mockResolvedValue("Success");


### PR DESCRIPTION
This ticket covers the work required to fix EDH marshaller lambda which sometimes fails when the payload is too big (It returns 413 errors)

If the lambda fails to process the message and throws an error, then it will log the error and it will retry up to X times (configurable from AWS, currently set to 3 times) or until the message expires (60 seconds), after which it will send the message to the respective DLQs for further investigation.

https://jira.dvsacloud.uk/browse/CVSB-17157